### PR TITLE
Make it work on Python 3

### DIFF
--- a/paramunittest.py
+++ b/paramunittest.py
@@ -92,8 +92,8 @@ class PropagateSetAttr(type):
 
 
 def make_propagator(cls, setattr_observers):
-    class SkippableTest(unittest.TestCase):
-        __metaclass__ = PropagateSetAttr
+    SkippableTest = PropagateSetAttr('SkippableTest', (unittest.TestCase,),
+                                     {})
     SkippableTest.setattr_observers.extend(setattr_observers)
     return SkippableTest
 


### PR DESCRIPTION
On Python 3 the `__metaclass__` attribute is ignored. So to make it work on both Python 2 and 3 the class must be explicitly created from the metaclass.
